### PR TITLE
feat: 404 page, mobile hamburger menu, sign-out fix with toast

### DIFF
--- a/app/api/auth/signout/route.ts
+++ b/app/api/auth/signout/route.ts
@@ -1,5 +1,6 @@
 import { signOut } from "@workos-inc/authkit-nextjs";
 
+/** Sign the user out and redirect back to the homepage. */
 export async function GET() {
-  await signOut();
+  return signOut({ returnTo: "/?toast=signed-out" });
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import { Geist, Geist_Mono } from "next/font/google";
 import { ThemeProvider } from "next-themes";
 import "./globals.css";
 import { ConvexClientProvider } from "@/components/ConvexClientProvider";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
+import { ToastProvider } from "@/components/ui/Toast";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -36,6 +38,9 @@ export default function RootLayout({
             <Header />
             <main className="min-h-[calc(100vh-8rem)]">{children}</main>
             <Footer />
+            <Suspense>
+              <ToastProvider />
+            </Suspense>
           </ConvexClientProvider>
         </ThemeProvider>
       </body>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+
+/** Global 404 not-found page shown when no route matches. */
+export default function NotFound() {
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col items-center justify-center px-6 py-32 text-center">
+      <p className="text-6xl font-bold text-accent">404</p>
+      <h1 className="mt-4 text-2xl font-semibold tracking-tight text-text-primary sm:text-3xl">
+        Page not found
+      </h1>
+      <p className="mt-3 text-text-secondary">
+        Sorry, the page you&apos;re looking for doesn&apos;t exist or has been
+        moved.
+      </p>
+      <Link
+        href="/"
+        className="mt-8 rounded-lg bg-accent px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-accent-hover"
+      >
+        Go back home
+      </Link>
+    </div>
+  );
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useConvexAuth, useQuery } from "convex/react";
@@ -8,10 +9,12 @@ import { useSyncExternalStore } from "react";
 import { api } from "@/convex/_generated/api";
 
 const emptySubscribe = () => () => {};
+/** Hydration-safe hook that returns true only on the client after mount. */
 function useIsMounted() {
   return useSyncExternalStore(emptySubscribe, () => true, () => false);
 }
 
+/** Dark / light theme toggle button. */
 function ThemeToggle() {
   const { theme, setTheme } = useTheme();
   const mounted = useIsMounted();
@@ -61,6 +64,57 @@ function ThemeToggle() {
   );
 }
 
+/** Hamburger / X icon toggle for mobile menu. */
+function MenuButton({
+  open,
+  onClick,
+}: {
+  open: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="rounded-lg p-2 text-text-secondary hover:bg-surface hover:text-text-primary transition-colors md:hidden"
+      aria-label={open ? "Close menu" : "Open menu"}
+      aria-expanded={open}
+    >
+      {open ? (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          className="h-5 w-5"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M6 18 18 6M6 6l12 12"
+          />
+        </svg>
+      ) : (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          className="h-5 w-5"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}
+
+/** Site-wide header with responsive navigation. */
 export function Header() {
   const { isAuthenticated } = useConvexAuth();
   const currentUser = useQuery(
@@ -68,6 +122,7 @@ export function Header() {
     isAuthenticated ? {} : "skip"
   );
   const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   const navLinks = [
     { href: "/blog", label: "Blog" },
@@ -75,47 +130,42 @@ export function Header() {
     { href: "/about", label: "About" },
   ];
 
+  if (currentUser?.isAdmin) {
+    navLinks.push({ href: "/admin", label: "Admin" });
+  }
+
+  const linkClass = (href: string) => {
+    const isActive = pathname === href || pathname.startsWith(href + "/");
+    return `rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+      isActive
+        ? "bg-accent-light text-accent"
+        : "text-text-secondary hover:bg-surface hover:text-text-primary"
+    }`;
+  };
+
+  const closeMobile = () => setMobileOpen(false);
+
   return (
     <header className="sticky top-0 z-50 border-b border-border bg-background/80 backdrop-blur-md">
+      {/* Desktop + mobile top bar */}
       <nav className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
-        <Link href="/" className="text-lg font-semibold text-text-primary">
+        <Link
+          href="/"
+          className="text-lg font-semibold text-text-primary"
+          onClick={closeMobile}
+        >
           Aman Kumar
         </Link>
 
-        <div className="flex items-center gap-1">
-          {navLinks.map(({ href, label }) => {
-            const isActive =
-              pathname === href || pathname.startsWith(href + "/");
-            return (
-              <Link
-                key={href}
-                href={href}
-                className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-                  isActive
-                    ? "bg-accent-light text-accent"
-                    : "text-text-secondary hover:bg-surface hover:text-text-primary"
-                }`}
-              >
-                {label}
-              </Link>
-            );
-          })}
-
-          {currentUser?.isAdmin && (
-            <Link
-              href="/admin"
-              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-                pathname.startsWith("/admin")
-                  ? "bg-accent-light text-accent"
-                  : "text-text-secondary hover:bg-surface hover:text-text-primary"
-              }`}
-            >
-              Admin
+        {/* Desktop nav */}
+        <div className="hidden items-center gap-1 md:flex">
+          {navLinks.map(({ href, label }) => (
+            <Link key={href} href={href} className={linkClass(href)}>
+              {label}
             </Link>
-          )}
+          ))}
 
           <div className="mx-2 h-5 w-px bg-border" />
-
           <ThemeToggle />
 
           {isAuthenticated ? (
@@ -147,7 +197,65 @@ export function Header() {
             </div>
           )}
         </div>
+
+        {/* Mobile: theme toggle + hamburger */}
+        <div className="flex items-center gap-1 md:hidden">
+          <ThemeToggle />
+          <MenuButton
+            open={mobileOpen}
+            onClick={() => setMobileOpen(!mobileOpen)}
+          />
+        </div>
       </nav>
+
+      {/* Mobile dropdown menu */}
+      {mobileOpen && (
+        <div className="border-t border-border bg-background px-6 pb-4 md:hidden">
+          <div className="flex flex-col gap-1 py-2">
+            {navLinks.map(({ href, label }) => (
+              <Link
+                key={href}
+                href={href}
+                className={linkClass(href) + " block"}
+                onClick={closeMobile}
+              >
+                {label}
+              </Link>
+            ))}
+          </div>
+
+          <div className="border-t border-border pt-3">
+            {isAuthenticated ? (
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-text-muted">
+                  {currentUser?.username ?? "User"}
+                </span>
+                <a
+                  href="/api/auth/signout"
+                  className="rounded-md bg-surface px-3 py-1.5 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-hover"
+                >
+                  Sign out
+                </a>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2">
+                <a
+                  href="/api/auth/signin"
+                  className="flex-1 rounded-md border border-border px-3 py-1.5 text-center text-sm font-medium text-text-secondary transition-colors hover:bg-surface"
+                >
+                  Sign in
+                </a>
+                <a
+                  href="/api/auth/signin?screen_hint=sign-up"
+                  className="flex-1 rounded-md bg-accent px-3 py-1.5 text-center text-sm font-medium text-white transition-colors hover:bg-accent-hover"
+                >
+                  Sign up
+                </a>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </header>
   );
 }

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useSyncExternalStore, useRef } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+
+const TOAST_MESSAGES: Record<string, string> = {
+  "signed-out": "Signed out successfully",
+};
+
+/* ---- tiny external toast store (avoids setState-in-effect lint rule) ---- */
+type ToastState = { message: string; visible: boolean };
+
+let state: ToastState = { message: "", visible: false };
+const listeners = new Set<() => void>();
+
+/** Return the current toast snapshot for useSyncExternalStore. */
+function getSnapshot(): ToastState {
+  return state;
+}
+
+/** Subscribe to toast state changes. */
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/** Show a toast message for 3 seconds. */
+function showToast(message: string) {
+  state = { message, visible: true };
+  listeners.forEach((l) => l());
+  setTimeout(() => {
+    state = { ...state, visible: false };
+    listeners.forEach((l) => l());
+  }, 3000);
+}
+
+/** Dismiss the current toast immediately. */
+function dismissToast() {
+  state = { ...state, visible: false };
+  listeners.forEach((l) => l());
+}
+
+/* ---- component ---- */
+
+/** A toast notification that reads from ?toast= URL params and auto-dismisses. */
+export function ToastProvider() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const toast = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const handledRef = useRef<string | null>(null);
+
+  const toastKey = searchParams.get("toast");
+
+  useEffect(() => {
+    if (toastKey && TOAST_MESSAGES[toastKey] && handledRef.current !== toastKey) {
+      handledRef.current = toastKey;
+      showToast(TOAST_MESSAGES[toastKey]);
+
+      // Remove toast param from URL without navigation
+      const url = new URL(window.location.href);
+      url.searchParams.delete("toast");
+      router.replace(url.pathname + url.search, { scroll: false });
+    }
+  }, [toastKey, router]);
+
+  if (!toast.visible) return null;
+
+  return (
+    <div className="fixed bottom-6 left-1/2 z-[100] -translate-x-1/2 animate-fade-in-up">
+      <div className="flex items-center gap-2 rounded-lg border border-border bg-surface px-4 py-3 shadow-lg">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          className="h-5 w-5 text-green-500"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+          />
+        </svg>
+        <span className="text-sm font-medium text-text-primary">
+          {toast.message}
+        </span>
+        <button
+          onClick={dismissToast}
+          className="ml-2 rounded p-0.5 text-text-muted hover:text-text-primary transition-colors"
+          aria-label="Dismiss"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="h-4 w-4"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M6 18 18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **404 page** — styled not-found page with "Go back home" button (closes #7)
- **Mobile hamburger menu** — responsive header with collapsible nav dropdown, visible on screens < 768px. Theme toggle + hamburger on mobile, full desktop nav on md+ (closes #14)
- **Sign-out fix** — pass `returnTo` param to WorkOS `signOut()` so users redirect to homepage instead of seeing "Couldn't sign in" error (closes #12)
- **Toast notification** — lightweight toast system using `useSyncExternalStore` external store pattern. Shows "Signed out successfully" popup that auto-dismisses after 3s

## Changes
| File | Change |
|---|---|
| `app/not-found.tsx` | **New** — 404 page |
| `components/layout/Header.tsx` | Rewrite — desktop nav hidden on mobile, hamburger menu + dropdown added |
| `app/api/auth/signout/route.ts` | Fix — pass `returnTo: "/?toast=signed-out"` to `signOut()` |
| `components/ui/Toast.tsx` | **New** — ToastProvider with external store |
| `app/layout.tsx` | Add `<Suspense><ToastProvider /></Suspense>` |

## Test plan
- [ ] Visit `/nonexistent-page` → see styled 404 page with back-home button
- [ ] On mobile viewport (< 768px): hamburger icon visible, tapping opens dropdown with nav + auth links
- [ ] On desktop (>= 768px): full nav bar as before, no hamburger
- [ ] Mobile menu closes when tapping a link or the logo
- [ ] Sign out → redirects to homepage, toast says "Signed out successfully"
- [ ] Toast auto-dismisses after 3 seconds, or can be manually dismissed
- [ ] `npm run lint` and `npm run typecheck` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile-responsive navigation menu with hamburger icon for improved mobile experience
  * Toast notification system for displaying real-time user feedback and action confirmations
  * New global 404 error page with easy navigation back to home
  * Admin navigation link now available for administrator users

* **Improvements**
  * Sign-out action now displays a confirmation toast notification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->