### PR TITLE
fix: use absolute URL for sign-out returnTo parameter

### DIFF
--- a/app/api/auth/signout/route.ts
+++ b/app/api/auth/signout/route.ts
@@ -1,6 +1,8 @@
+import { NextRequest } from "next/server";
 import { signOut } from "@workos-inc/authkit-nextjs";
 
-/** Sign the user out and redirect back to the homepage. */
-export async function GET() {
-  return signOut({ returnTo: "/?toast=signed-out" });
+/** Sign the user out and redirect back to the homepage with a toast. */
+export async function GET(request: NextRequest) {
+  const { origin } = new URL(request.url);
+  return signOut({ returnTo: `${origin}/?toast=signed-out` });
 }


### PR DESCRIPTION
WorkOS logout endpoint requires a full absolute URL for the returnTo redirect, not a relative path. Build it from the request origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the sign-out experience to dynamically redirect to your site's origin with a confirmation toast, ensuring proper functionality across different deployment environments and access configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->