### PR TITLE
fix: sign-out cookie bypass, middleware auth paths, toast position

### DIFF
--- a/app/api/auth/signout/route.ts
+++ b/app/api/auth/signout/route.ts
@@ -1,12 +1,8 @@
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
+import { NextRequest } from "next/server";
+import { signOut } from "@workos-inc/authkit-nextjs";
 
-/**
- * Sign the user out by clearing the session cookie and redirecting home.
- * Bypasses WorkOS logout endpoint which was causing a "Couldn't sign in" error.
- */
-export async function GET() {
-  const cookieStore = await cookies();
-  cookieStore.delete("wos-session");
-  redirect("/?toast=signed-out");
+/** Sign the user out and redirect back to the homepage with a toast. */
+export async function GET(request: NextRequest) {
+  const { origin } = new URL(request.url);
+  return signOut({ returnTo: `${origin}/?toast=signed-out` });
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -11,7 +11,6 @@ export default authkitMiddleware({
       "/projects",
       "/projects/(.*)",
       "/callback",
-      "/api/auth/(.*)",
     ],
   },
 });


### PR DESCRIPTION
## Summary
These 3 commits were pushed to the `feat/ux-fixes-7-12-14` branch after PR #25 was already merged, so they didn't make it into main.

- **Bypass WorkOS logout endpoint** — clear `wos-session` cookie directly instead of redirecting through WorkOS's logout URL (which was causing "Couldn't sign in" error)
- **Add `/api/auth/(.*)` to unauthenticatedPaths** — prevents middleware from intercepting sign-in/sign-out routes
- **Move toast to top-right** — position below nav bar instead of bottom-center

## Test plan
- [ ] Sign out → redirects to homepage, toast appears top-right
- [ ] Toast auto-dismisses after 3s
- [ ] Sign in still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Toast notifications repositioned from bottom-center to top-right for improved visibility.

* **Bug Fixes**
  * Enhanced sign-out flow with confirmation feedback displayed via toast notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->