### PR TITLE
feat: Reddit-style soft deletion for comments

### DIFF
--- a/components/blog/CommentSection.tsx
+++ b/components/blog/CommentSection.tsx
@@ -15,6 +15,7 @@ type CommentWithAuthor = {
   postId: Id<"posts">;
   parentId?: Id<"comments">;
   createdAt: number;
+  deletedAt?: number;
   authorUsername: string;
   authorAvatarUrl: string | null;
   authorIsAdmin: boolean;
@@ -134,84 +135,97 @@ function Comment({
 }) {
   const [showReplyForm, setShowReplyForm] = useState(false);
 
+  const isDeleted = !!comment.deletedAt;
   const isOwner = currentUser?._id === comment.authorId;
-  const canDelete = isOwner || currentUser?.isAdmin;
+  const canDelete = !isDeleted && (isOwner || currentUser?.isAdmin);
 
   return (
     <div className={depth > 0 ? "ml-6 border-l-2 border-border pl-4" : ""}>
-      <div className="group rounded-lg border border-border bg-background p-4 transition-colors hover:border-border-hover">
-        <div className="flex items-start justify-between">
-          <div className="flex items-center gap-2">
-            {comment.authorAvatarUrl ? (
-              <Image
-                src={comment.authorAvatarUrl}
-                alt={comment.authorUsername}
-                width={28}
-                height={28}
-                className="h-7 w-7 rounded-full"
-              />
-            ) : (
-              <div className="flex h-7 w-7 items-center justify-center rounded-full bg-accent-light text-xs font-medium text-accent">
-                {comment.authorUsername.charAt(0).toUpperCase()}
-              </div>
-            )}
-            <span className="text-sm font-medium text-text-primary">
-              {comment.authorUsername}
-            </span>
-            {comment.authorIsAdmin && (
-              <span className="rounded-full bg-accent px-1.5 py-0.5 text-[10px] font-semibold uppercase text-white">
-                Admin
-              </span>
-            )}
-            <span className="text-xs text-text-muted">
-              {formatDate(comment.createdAt)}
-            </span>
-          </div>
-
-          <div className="flex items-center gap-1">
-            {isAuthenticated && (
-              <button
-                onClick={() => setShowReplyForm(!showReplyForm)}
-                className="rounded p-1 text-xs text-text-muted opacity-0 transition-all hover:text-accent group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
-              >
-                Reply{comment.replies.length > 0 ? ` (${comment.replies.length})` : ""}
-              </button>
-            )}
-            {canDelete && (
-              <button
-                onClick={() => onDelete(comment._id)}
-                className="rounded p-1 text-text-muted opacity-0 transition-all hover:bg-surface hover:text-red-500 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
-                aria-label="Delete comment"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth={1.5}
-                  stroke="currentColor"
-                  className="h-4 w-4"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
+      <div
+        className={`group rounded-lg border border-border p-4 transition-colors ${
+          isDeleted
+            ? "bg-surface opacity-60"
+            : "bg-background hover:border-border-hover"
+        }`}
+      >
+        {isDeleted ? (
+          <p className="text-sm italic text-text-muted">[deleted]</p>
+        ) : (
+          <>
+            <div className="flex items-start justify-between">
+              <div className="flex items-center gap-2">
+                {comment.authorAvatarUrl ? (
+                  <Image
+                    src={comment.authorAvatarUrl}
+                    alt={comment.authorUsername}
+                    width={28}
+                    height={28}
+                    className="h-7 w-7 rounded-full"
                   />
-                </svg>
-              </button>
+                ) : (
+                  <div className="flex h-7 w-7 items-center justify-center rounded-full bg-accent-light text-xs font-medium text-accent">
+                    {comment.authorUsername.charAt(0).toUpperCase()}
+                  </div>
+                )}
+                <span className="text-sm font-medium text-text-primary">
+                  {comment.authorUsername}
+                </span>
+                {comment.authorIsAdmin && (
+                  <span className="rounded-full bg-accent px-1.5 py-0.5 text-[10px] font-semibold uppercase text-white">
+                    Admin
+                  </span>
+                )}
+                <span className="text-xs text-text-muted">
+                  {formatDate(comment.createdAt)}
+                </span>
+              </div>
+
+              <div className="flex items-center gap-1">
+                {isAuthenticated && (
+                  <button
+                    onClick={() => setShowReplyForm(!showReplyForm)}
+                    className="rounded p-1 text-xs text-text-muted opacity-0 transition-all hover:text-accent group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                  >
+                    Reply{comment.replies.length > 0 ? ` (${comment.replies.length})` : ""}
+                  </button>
+                )}
+                {canDelete && (
+                  <button
+                    onClick={() => onDelete(comment._id)}
+                    className="rounded p-1 text-text-muted opacity-0 transition-all hover:bg-surface hover:text-red-500 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                    aria-label="Delete comment"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      strokeWidth={1.5}
+                      stroke="currentColor"
+                      className="h-4 w-4"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
+                      />
+                    </svg>
+                  </button>
+                )}
+              </div>
+            </div>
+
+            <p className="mt-2 whitespace-pre-wrap text-sm text-text-secondary">
+              {comment.text}
+            </p>
+
+            {showReplyForm && (
+              <ReplyForm
+                postId={postId}
+                parentId={comment._id}
+                onDone={() => setShowReplyForm(false)}
+              />
             )}
-          </div>
-        </div>
-
-        <p className="mt-2 whitespace-pre-wrap text-sm text-text-secondary">
-          {comment.text}
-        </p>
-
-        {showReplyForm && (
-          <ReplyForm
-            postId={postId}
-            parentId={comment._id}
-            onDone={() => setShowReplyForm(false)}
-          />
+          </>
         )}
       </div>
 
@@ -270,7 +284,7 @@ export function CommentSection({ postId }: { postId: Id<"posts"> }) {
   };
 
   const commentTree = comments ? buildCommentTree(comments) : undefined;
-  const totalCount = comments?.length ?? 0;
+  const totalCount = comments?.filter((c) => !c.deletedAt).length ?? 0;
 
   return (
     <section className="mt-12 border-t border-border pt-8">

--- a/convex/comments.ts
+++ b/convex/comments.ts
@@ -15,6 +15,15 @@ export const getByPostId = query({
     // Join with users table to include username and avatarUrl
     const commentsWithAuthors = await Promise.all(
       comments.map(async (comment) => {
+        // Skip author lookup for tombstoned comments
+        if (comment.deletedAt) {
+          return {
+            ...comment,
+            authorUsername: "[deleted]",
+            authorAvatarUrl: null,
+            authorIsAdmin: false,
+          };
+        }
         const author = await ctx.db.get(comment.authorId);
         return {
           ...comment,
@@ -62,7 +71,8 @@ export const create = mutation({
   },
 });
 
-/** Delete a comment and all its replies. Only the comment author or an admin can delete. */
+/** Delete a comment. If it has replies, soft-delete (tombstone) to preserve the thread.
+ *  If it's a leaf, hard-delete and prune any orphaned tombstone ancestors. */
 export const remove = mutation({
   args: { id: v.id("comments") },
   handler: async (ctx, args) => {
@@ -76,27 +86,41 @@ export const remove = mutation({
       throw new Error("Forbidden: you can only delete your own comments");
     }
 
-    // Iterative cascade delete: collect all descendants, then delete in reverse
-    const toVisit: (typeof args.id)[] = [args.id];
-    const postOrder: (typeof args.id)[] = [];
+    // Check if this comment has any replies
+    const hasReplies = await ctx.db
+      .query("comments")
+      .withIndex("by_parent", (q) => q.eq("parentId", args.id))
+      .first();
 
-    while (toVisit.length > 0) {
-      const currentId = toVisit.pop()!;
-      postOrder.push(currentId);
+    if (hasReplies !== null) {
+      // Has children → soft delete (tombstone): keep the row so the thread is preserved
+      await ctx.db.patch(args.id, {
+        deletedAt: Date.now(),
+        text: "[deleted]",
+      });
+    } else {
+      // Leaf node → hard delete, then prune orphaned tombstone ancestors
+      await ctx.db.delete(args.id);
 
-      const replies = await ctx.db
-        .query("comments")
-        .withIndex("by_parent", (q) => q.eq("parentId", currentId))
-        .collect();
+      // Walk up the ancestor chain pruning unnecessary tombstones
+      let ancestorId = comment.parentId;
+      while (ancestorId) {
+        const ancestor = await ctx.db.get(ancestorId);
+        if (!ancestor || !ancestor.deletedAt) break;
 
-      for (const reply of replies) {
-        toVisit.push(reply._id);
+        // Does this tombstone ancestor still have any remaining children?
+        const remainingSibling = await ctx.db
+          .query("comments")
+          .withIndex("by_parent", (q) => q.eq("parentId", ancestorId!))
+          .first();
+
+        if (remainingSibling !== null) break;
+
+        // Ancestor is a tombstone with no children — prune it
+        const nextAncestorId = ancestor.parentId;
+        await ctx.db.delete(ancestorId);
+        ancestorId = nextAncestorId;
       }
-    }
-
-    // Delete in reverse (children before parents)
-    for (let i = postOrder.length - 1; i >= 0; i--) {
-      await ctx.db.delete(postOrder[i]);
     }
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -50,6 +50,7 @@ export default defineSchema({
     postId: v.id("posts"),
     parentId: v.optional(v.id("comments")),
     createdAt: v.number(),
+    deletedAt: v.optional(v.number()),
   })
     .index("by_post", ["postId", "createdAt"])
     .index("by_author", ["authorId"])


### PR DESCRIPTION
## Summary
Implements Reddit-style comment deletion (tombstone pattern):
- **Parent comments with replies** are soft-deleted — show as "[deleted]" while preserving the thread
- **Leaf comments** (no replies) are hard-deleted from the database
- **Orphaned tombstone ancestors** are automatically pruned when their last descendant is removed

## Changes
- `convex/schema.ts` — Added `deletedAt: v.optional(v.number())` to comments table
- `convex/comments.ts` — Rewrote `remove` mutation (soft delete vs hard delete + ancestor pruning), optimized `getByPostId` to skip author lookups for tombstones
- `components/blog/CommentSection.tsx` — Added `deletedAt` to type, tombstone rendering (muted "[deleted]" placeholder), comment count excludes tombstones

## Test plan
- [ ] Delete a comment with replies → shows "[deleted]", replies remain visible
- [ ] Delete a leaf comment (no replies) → fully removed from DB
- [ ] Delete the last reply under a tombstone parent → parent tombstone is also pruned
- [ ] Comment count in header excludes tombstones
- [ ] Tombstone shows no avatar, username, admin badge, or action buttons
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now delete comments. Deleted comments display as "[deleted]" and are excluded from total comment counts.
  * When a comment with replies is deleted, the comment text is replaced with a "[deleted]" placeholder while preserving the thread structure.
  * Delete controls are unavailable for comments that have already been deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->