### PR TITLE
feat: thumbnail images + cursor-based pagination

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -7,10 +7,15 @@ import { CommentSection } from "@/components/blog/CommentSection";
 import { MarkdownContent } from "@/components/blog/MarkdownContent";
 import { AnimateOnScroll } from "@/components/ui/AnimateOnScroll";
 import Link from "next/link";
+import Image from "next/image";
 
 export default function BlogPostPage() {
   const { slug } = useParams<{ slug: string }>();
   const post = useQuery(api.posts.getBySlug, { slug });
+  const thumbnailUrl = useQuery(
+    api.files.getUrl,
+    post?.thumbnailId ? { storageId: post.thumbnailId } : "skip"
+  );
 
   if (post === undefined) {
     return (
@@ -77,6 +82,19 @@ export default function BlogPostPage() {
               )}
             </div>
           </header>
+
+          {thumbnailUrl && (
+            <div className="relative mb-8 aspect-[768/400] w-full overflow-hidden rounded-xl">
+              <Image
+                src={thumbnailUrl}
+                alt={post.title}
+                fill
+                className="object-cover"
+                sizes="(max-width: 768px) 100vw, 768px"
+                priority
+              />
+            </div>
+          )}
 
           <MarkdownContent content={post.content} />
         </article>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,12 +1,19 @@
 "use client";
 
-import { useQuery } from "convex/react";
+import { usePaginatedQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { PostCard } from "@/components/blog/PostCard";
 import { AnimateOnScroll } from "@/components/ui/AnimateOnScroll";
+import { useThumbnailUrls } from "@/hooks/useThumbnailUrls";
 
 export default function BlogPage() {
-  const posts = useQuery(api.posts.listPublished);
+  const { results, status, loadMore } = usePaginatedQuery(
+    api.posts.listPublishedPaginated,
+    {},
+    { initialNumItems: 10 }
+  );
+
+  const thumbnailUrls = useThumbnailUrls(results);
 
   return (
     <div className="mx-auto max-w-5xl px-6 py-20">
@@ -20,16 +27,43 @@ export default function BlogPage() {
       </AnimateOnScroll>
 
       <AnimateOnScroll variant="slide-up" delay={100} className="mt-10">
-        {posts === undefined ? (
+        {status === "LoadingFirstPage" ? (
           <p className="text-text-muted">Loading...</p>
-        ) : posts.length === 0 ? (
+        ) : results.length === 0 ? (
           <p className="text-text-muted">No posts yet. Check back soon!</p>
         ) : (
-          <div className="space-y-1">
-            {posts.map((post) => (
-              <PostCard key={post._id} post={post} />
-            ))}
-          </div>
+          <>
+            <div className="space-y-1">
+              {results.map((post) => (
+                <PostCard
+                  key={post._id}
+                  post={post}
+                  thumbnailUrl={
+                    post.thumbnailId
+                      ? thumbnailUrls[post.thumbnailId]
+                      : undefined
+                  }
+                />
+              ))}
+            </div>
+
+            {status === "CanLoadMore" && (
+              <div className="mt-10 text-center">
+                <button
+                  onClick={() => loadMore(10)}
+                  className="rounded-lg border border-border px-6 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:border-accent/40 hover:bg-surface hover:text-text-primary"
+                >
+                  Load more posts
+                </button>
+              </div>
+            )}
+
+            {status === "LoadingMore" && (
+              <p className="mt-10 text-center text-sm text-text-muted">
+                Loading more...
+              </p>
+            )}
+          </>
         )}
       </AnimateOnScroll>
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import { api } from "@/convex/_generated/api";
 import { PostCard } from "@/components/blog/PostCard";
 import { ProjectCard } from "@/components/projects/ProjectCard";
 import { AnimateOnScroll } from "@/components/ui/AnimateOnScroll";
+import { useThumbnailUrls } from "@/hooks/useThumbnailUrls";
 
 export default function Home() {
   const posts = useQuery(api.posts.listPublished);
@@ -13,6 +14,9 @@ export default function Home() {
 
   const recentPosts = posts?.slice(0, 3);
   const featuredProjects = projects?.slice(0, 3);
+
+  const postThumbnailUrls = useThumbnailUrls(recentPosts);
+  const projectThumbnailUrls = useThumbnailUrls(featuredProjects);
 
   return (
     <>
@@ -104,7 +108,15 @@ export default function Home() {
           ) : (
             <div className="space-y-1">
               {recentPosts.map((post) => (
-                <PostCard key={post._id} post={post} />
+                <PostCard
+                  key={post._id}
+                  post={post}
+                  thumbnailUrl={
+                    post.thumbnailId
+                      ? postThumbnailUrls[post.thumbnailId]
+                      : undefined
+                  }
+                />
               ))}
             </div>
           )}
@@ -134,7 +146,15 @@ export default function Home() {
           ) : (
             <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
               {featuredProjects.map((project) => (
-                <ProjectCard key={project._id} project={project} />
+                <ProjectCard
+                  key={project._id}
+                  project={project}
+                  thumbnailUrl={
+                    project.thumbnailId
+                      ? projectThumbnailUrls[project.thumbnailId]
+                      : undefined
+                  }
+                />
               ))}
             </div>
           )}

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -5,10 +5,15 @@ import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { AnimateOnScroll } from "@/components/ui/AnimateOnScroll";
 import Link from "next/link";
+import Image from "next/image";
 
 export default function ProjectDetailPage() {
   const { slug } = useParams<{ slug: string }>();
   const project = useQuery(api.projects.getBySlug, { slug });
+  const thumbnailUrl = useQuery(
+    api.files.getUrl,
+    project?.thumbnailId ? { storageId: project.thumbnailId } : "skip"
+  );
 
   if (project === undefined) {
     return (
@@ -85,6 +90,19 @@ export default function ProjectDetailPage() {
               )}
             </div>
           </header>
+
+          {thumbnailUrl && (
+            <div className="relative mb-8 aspect-[768/400] w-full overflow-hidden rounded-xl">
+              <Image
+                src={thumbnailUrl}
+                alt={project.title}
+                fill
+                className="object-cover"
+                sizes="(max-width: 768px) 100vw, 768px"
+                priority
+              />
+            </div>
+          )}
 
           {project.longDescription && (
             <div className="prose max-w-none">

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,12 +1,19 @@
 "use client";
 
-import { useQuery } from "convex/react";
+import { usePaginatedQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { ProjectCard } from "@/components/projects/ProjectCard";
 import { AnimateOnScroll } from "@/components/ui/AnimateOnScroll";
+import { useThumbnailUrls } from "@/hooks/useThumbnailUrls";
 
 export default function ProjectsPage() {
-  const projects = useQuery(api.projects.listPublished);
+  const { results, status, loadMore } = usePaginatedQuery(
+    api.projects.listPublishedPaginated,
+    {},
+    { initialNumItems: 9 }
+  );
+
+  const thumbnailUrls = useThumbnailUrls(results);
 
   return (
     <div className="mx-auto max-w-5xl px-6 py-20">
@@ -20,18 +27,45 @@ export default function ProjectsPage() {
       </AnimateOnScroll>
 
       <AnimateOnScroll variant="slide-up" delay={100} className="mt-10">
-        {projects === undefined ? (
+        {status === "LoadingFirstPage" ? (
           <p className="text-text-muted">Loading...</p>
-        ) : projects.length === 0 ? (
+        ) : results.length === 0 ? (
           <p className="text-text-muted">
             No projects yet. Check back soon!
           </p>
         ) : (
-          <div className="grid gap-6 sm:grid-cols-2">
-            {projects.map((project) => (
-              <ProjectCard key={project._id} project={project} />
-            ))}
-          </div>
+          <>
+            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {results.map((project) => (
+                <ProjectCard
+                  key={project._id}
+                  project={project}
+                  thumbnailUrl={
+                    project.thumbnailId
+                      ? thumbnailUrls[project.thumbnailId]
+                      : undefined
+                  }
+                />
+              ))}
+            </div>
+
+            {status === "CanLoadMore" && (
+              <div className="mt-10 text-center">
+                <button
+                  onClick={() => loadMore(9)}
+                  className="rounded-lg border border-border px-6 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:border-accent/40 hover:bg-surface hover:text-text-primary"
+                >
+                  Load more projects
+                </button>
+              </div>
+            )}
+
+            {status === "LoadingMore" && (
+              <p className="mt-10 text-center text-sm text-text-muted">
+                Loading more...
+              </p>
+            )}
+          </>
         )}
       </AnimateOnScroll>
     </div>

--- a/components/admin/PostForm.tsx
+++ b/components/admin/PostForm.tsx
@@ -4,7 +4,8 @@ import { useState } from "react";
 import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useRouter } from "next/navigation";
-import { Doc } from "@/convex/_generated/dataModel";
+import { Doc, Id } from "@/convex/_generated/dataModel";
+import { ThumbnailUpload } from "./ThumbnailUpload";
 
 function toSlug(title: string) {
   return title
@@ -24,6 +25,9 @@ export function PostForm({ post }: { post?: Doc<"posts"> }) {
   const [excerpt, setExcerpt] = useState(post?.excerpt ?? "");
   const [tags, setTags] = useState(post?.tags?.join(", ") ?? "");
   const [isPublished, setIsPublished] = useState(post?.isPublished ?? false);
+  const [thumbnailId, setThumbnailId] = useState<Id<"_storage"> | undefined>(
+    post?.thumbnailId
+  );
   const [saving, setSaving] = useState(false);
 
   async function handleSubmit(e: React.FormEvent) {
@@ -44,6 +48,7 @@ export function PostForm({ post }: { post?: Doc<"posts"> }) {
           content,
           excerpt: excerpt || undefined,
           tags: parsedTags.length > 0 ? parsedTags : undefined,
+          thumbnailId,
           isPublished,
         });
       } else {
@@ -53,6 +58,7 @@ export function PostForm({ post }: { post?: Doc<"posts"> }) {
           content,
           excerpt: excerpt || undefined,
           tags: parsedTags.length > 0 ? parsedTags : undefined,
+          thumbnailId,
           isPublished,
         });
       }
@@ -106,6 +112,12 @@ export function PostForm({ post }: { post?: Doc<"posts"> }) {
           className="mt-1 block w-full rounded-md border border-zinc-300 px-3 py-2 text-zinc-900 focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
         />
       </div>
+
+      <ThumbnailUpload
+        currentThumbnailId={thumbnailId}
+        onUpload={(id) => setThumbnailId(id)}
+        onRemove={() => setThumbnailId(undefined)}
+      />
 
       <div>
         <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">

--- a/components/admin/ProjectForm.tsx
+++ b/components/admin/ProjectForm.tsx
@@ -4,7 +4,8 @@ import { useState } from "react";
 import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useRouter } from "next/navigation";
-import { Doc } from "@/convex/_generated/dataModel";
+import { Doc, Id } from "@/convex/_generated/dataModel";
+import { ThumbnailUpload } from "./ThumbnailUpload";
 
 function toSlug(title: string) {
   return title
@@ -35,6 +36,9 @@ export function ProjectForm({ project }: { project?: Doc<"projects"> }) {
   const [isPublished, setIsPublished] = useState(
     project?.isPublished ?? false
   );
+  const [thumbnailId, setThumbnailId] = useState<Id<"_storage"> | undefined>(
+    project?.thumbnailId
+  );
   const [saving, setSaving] = useState(false);
 
   async function handleSubmit(e: React.FormEvent) {
@@ -57,6 +61,7 @@ export function ProjectForm({ project }: { project?: Doc<"projects"> }) {
           url: url || undefined,
           repoUrl: repoUrl || undefined,
           techStack: parsedTechStack,
+          thumbnailId,
           sortOrder,
           isPublished,
         });
@@ -69,6 +74,7 @@ export function ProjectForm({ project }: { project?: Doc<"projects"> }) {
           url: url || undefined,
           repoUrl: repoUrl || undefined,
           techStack: parsedTechStack,
+          thumbnailId,
           sortOrder,
           isPublished,
         });
@@ -124,6 +130,12 @@ export function ProjectForm({ project }: { project?: Doc<"projects"> }) {
           className="mt-1 block w-full rounded-md border border-zinc-300 px-3 py-2 text-zinc-900 focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
         />
       </div>
+
+      <ThumbnailUpload
+        currentThumbnailId={thumbnailId}
+        onUpload={(id) => setThumbnailId(id)}
+        onRemove={() => setThumbnailId(undefined)}
+      />
 
       <div>
         <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">

--- a/components/admin/ThumbnailUpload.tsx
+++ b/components/admin/ThumbnailUpload.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { Id } from "@/convex/_generated/dataModel";
+import Image from "next/image";
+
+interface ThumbnailUploadProps {
+  currentThumbnailId?: Id<"_storage">;
+  onUpload: (storageId: Id<"_storage">) => void;
+  onRemove: () => void;
+}
+
+export function ThumbnailUpload({
+  currentThumbnailId,
+  onUpload,
+  onRemove,
+}: ThumbnailUploadProps) {
+  const generateUploadUrl = useMutation(api.files.generateUploadUrl);
+  const deleteFile = useMutation(api.files.deleteFile);
+
+  const thumbnailUrl = useQuery(
+    api.files.getUrl,
+    currentThumbnailId ? { storageId: currentThumbnailId } : "skip"
+  );
+
+  const [uploading, setUploading] = useState(false);
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setUploading(true);
+    try {
+      const uploadUrl = await generateUploadUrl();
+      const result = await fetch(uploadUrl, {
+        method: "POST",
+        headers: { "Content-Type": file.type },
+        body: file,
+      });
+      const { storageId } = await result.json();
+      onUpload(storageId as Id<"_storage">);
+    } catch (error) {
+      console.error("Upload failed:", error);
+    } finally {
+      setUploading(false);
+      // Reset the input so the same file can be re-selected
+      e.target.value = "";
+    }
+  }
+
+  async function handleRemove() {
+    if (currentThumbnailId) {
+      try {
+        await deleteFile({ storageId: currentThumbnailId });
+      } catch {
+        // File might already be deleted — that's fine
+      }
+    }
+    onRemove();
+  }
+
+  return (
+    <div>
+      <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        Thumbnail
+      </label>
+
+      {currentThumbnailId && thumbnailUrl ? (
+        <div className="mt-2 flex items-start gap-4">
+          <div className="relative h-20 w-32 overflow-hidden rounded-lg border border-zinc-300 dark:border-zinc-700">
+            <Image
+              src={thumbnailUrl}
+              alt="Thumbnail preview"
+              fill
+              className="object-cover"
+              sizes="128px"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={handleRemove}
+            className="rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-600 transition-colors hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950"
+          >
+            Remove
+          </button>
+        </div>
+      ) : (
+        <div className="mt-2">
+          <label className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-zinc-300 px-3 py-1.5 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800">
+            {uploading ? (
+              "Uploading..."
+            ) : (
+              <>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                  className="h-4 w-4"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"
+                  />
+                </svg>
+                Upload Image
+              </>
+            )}
+            <input
+              type="file"
+              accept="image/png,image/jpeg,image/webp,image/gif"
+              onChange={handleFileChange}
+              disabled={uploading}
+              className="hidden"
+            />
+          </label>
+          <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+            PNG, JPG, WebP, or GIF. Recommended 1200×630 for best results.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/blog/PostCard.tsx
+++ b/components/blog/PostCard.tsx
@@ -1,7 +1,13 @@
 import Link from "next/link";
+import Image from "next/image";
 import { Doc } from "@/convex/_generated/dataModel";
 
-export function PostCard({ post }: { post: Doc<"posts"> }) {
+interface PostCardProps {
+  post: Doc<"posts">;
+  thumbnailUrl?: string | null;
+}
+
+export function PostCard({ post, thumbnailUrl }: PostCardProps) {
   const date = post.publishedAt
     ? new Date(post.publishedAt).toLocaleDateString("en-US", {
         year: "numeric",
@@ -14,31 +20,45 @@ export function PostCard({ post }: { post: Doc<"posts"> }) {
     <article className="group">
       <Link
         href={`/blog/${post.slug}`}
-        className="-mx-5 block rounded-xl border border-transparent p-5 transition-all duration-300 hover:border-border hover:bg-surface/50 hover:shadow-[0_0_20px_rgba(79,143,255,0.06)]"
+        className="-mx-5 flex items-center gap-5 rounded-xl border border-transparent p-5 transition-all duration-300 hover:border-border hover:bg-surface/50 hover:shadow-[0_0_20px_rgba(79,143,255,0.06)]"
       >
-        <h2 className="text-xl font-semibold text-text-primary transition-colors group-hover:text-accent">
-          {post.title}
-        </h2>
-        {post.excerpt && (
-          <p className="mt-2 line-clamp-2 text-text-secondary">
-            {post.excerpt}
-          </p>
-        )}
-        <div className="mt-3 flex items-center gap-3">
-          {date && <time className="text-sm text-text-muted">{date}</time>}
-          {post.tags && post.tags.length > 0 && (
-            <div className="flex gap-2">
-              {post.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="rounded-full bg-accent-light px-2.5 py-0.5 text-xs font-medium text-accent"
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
+        <div className="min-w-0 flex-1">
+          <h2 className="text-xl font-semibold text-text-primary transition-colors group-hover:text-accent">
+            {post.title}
+          </h2>
+          {post.excerpt && (
+            <p className="mt-2 line-clamp-2 text-text-secondary">
+              {post.excerpt}
+            </p>
           )}
+          <div className="mt-3 flex items-center gap-3">
+            {date && <time className="text-sm text-text-muted">{date}</time>}
+            {post.tags && post.tags.length > 0 && (
+              <div className="flex gap-2">
+                {post.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full bg-accent-light px-2.5 py-0.5 text-xs font-medium text-accent"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
+
+        {thumbnailUrl && (
+          <div className="relative hidden h-20 w-[120px] shrink-0 overflow-hidden rounded-lg sm:block">
+            <Image
+              src={thumbnailUrl}
+              alt={post.title}
+              fill
+              className="object-cover"
+              sizes="120px"
+            />
+          </div>
+        )}
       </Link>
     </article>
   );

--- a/components/projects/ProjectCard.tsx
+++ b/components/projects/ProjectCard.tsx
@@ -1,16 +1,39 @@
 import Link from "next/link";
+import Image from "next/image";
 import { Doc } from "@/convex/_generated/dataModel";
 
-export function ProjectCard({ project }: { project: Doc<"projects"> }) {
+interface ProjectCardProps {
+  project: Doc<"projects">;
+  thumbnailUrl?: string | null;
+}
+
+export function ProjectCard({ project, thumbnailUrl }: ProjectCardProps) {
   return (
     <article className="group rounded-xl border border-border bg-surface p-6 transition-all duration-300 hover:-translate-y-1 hover:border-accent/40 hover:shadow-[0_4px_30px_rgba(79,143,255,0.1)]">
       <Link href={`/projects/${project.slug}`} className="block">
-        <h2 className="text-lg font-semibold text-text-primary transition-colors group-hover:text-accent">
-          {project.title}
-        </h2>
-        <p className="mt-2 line-clamp-2 text-sm text-text-secondary">
-          {project.description}
-        </p>
+        <div className="flex items-start gap-4">
+          <div className="min-w-0 flex-1">
+            <h2 className="text-lg font-semibold text-text-primary transition-colors group-hover:text-accent">
+              {project.title}
+            </h2>
+            <p className="mt-2 line-clamp-2 text-sm text-text-secondary">
+              {project.description}
+            </p>
+          </div>
+
+          {thumbnailUrl && (
+            <div className="relative hidden h-20 w-20 shrink-0 overflow-hidden rounded-lg sm:block">
+              <Image
+                src={thumbnailUrl}
+                alt={project.title}
+                fill
+                className="object-cover"
+                sizes="80px"
+              />
+            </div>
+          )}
+        </div>
+
         <div className="mt-4 flex flex-wrap gap-2">
           {project.techStack.map((tech) => (
             <span

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as about from "../about.js";
 import type * as comments from "../comments.js";
+import type * as files from "../files.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as posts from "../posts.js";
 import type * as projects from "../projects.js";
@@ -24,6 +25,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   about: typeof about;
   comments: typeof comments;
+  files: typeof files;
   "lib/auth": typeof lib_auth;
   posts: typeof posts;
   projects: typeof projects;

--- a/convex/files.ts
+++ b/convex/files.ts
@@ -1,0 +1,43 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { requireAdmin } from "./lib/auth";
+
+/** Generate a short-lived upload URL for Convex file storage (admin only). */
+export const generateUploadUrl = mutation({
+  args: {},
+  handler: async (ctx) => {
+    await requireAdmin(ctx);
+    return await ctx.storage.generateUploadUrl();
+  },
+});
+
+/** Get the serving URL for a single storage file. */
+export const getUrl = query({
+  args: { storageId: v.id("_storage") },
+  handler: async (ctx, args) => {
+    return await ctx.storage.getUrl(args.storageId);
+  },
+});
+
+/** Batch-resolve storage IDs to URLs. Returns a record of id → url|null. */
+export const getUrls = query({
+  args: { storageIds: v.array(v.id("_storage")) },
+  handler: async (ctx, args) => {
+    const result: Record<string, string | null> = {};
+    await Promise.all(
+      args.storageIds.map(async (id) => {
+        result[id] = await ctx.storage.getUrl(id);
+      })
+    );
+    return result;
+  },
+});
+
+/** Delete a file from storage (admin only). */
+export const deleteFile = mutation({
+  args: { storageId: v.id("_storage") },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+    await ctx.storage.delete(args.storageId);
+  },
+});

--- a/convex/posts.ts
+++ b/convex/posts.ts
@@ -1,4 +1,5 @@
 import { mutation, query } from "./_generated/server";
+import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 import { requireAdmin } from "./lib/auth";
 
@@ -10,6 +11,17 @@ export const listPublished = query({
       .withIndex("by_published", (q) => q.eq("isPublished", true))
       .order("desc")
       .collect();
+  },
+});
+
+export const listPublishedPaginated = query({
+  args: { paginationOpts: paginationOptsValidator },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("posts")
+      .withIndex("by_published", (q) => q.eq("isPublished", true))
+      .order("desc")
+      .paginate(args.paginationOpts);
   },
 });
 
@@ -42,6 +54,7 @@ export const create = mutation({
     excerpt: v.optional(v.string()),
     isPublished: v.boolean(),
     tags: v.optional(v.array(v.string())),
+    thumbnailId: v.optional(v.id("_storage")),
   },
   handler: async (ctx, args) => {
     const user = await requireAdmin(ctx);
@@ -64,6 +77,7 @@ export const update = mutation({
     excerpt: v.optional(v.string()),
     isPublished: v.optional(v.boolean()),
     tags: v.optional(v.array(v.string())),
+    thumbnailId: v.optional(v.id("_storage")),
   },
   handler: async (ctx, args) => {
     await requireAdmin(ctx);

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -1,4 +1,5 @@
 import { mutation, query } from "./_generated/server";
+import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 import { requireAdmin } from "./lib/auth";
 
@@ -10,6 +11,17 @@ export const listPublished = query({
       .withIndex("by_published", (q) => q.eq("isPublished", true))
       .order("asc")
       .collect();
+  },
+});
+
+export const listPublishedPaginated = query({
+  args: { paginationOpts: paginationOptsValidator },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("projects")
+      .withIndex("by_published", (q) => q.eq("isPublished", true))
+      .order("asc")
+      .paginate(args.paginationOpts);
   },
 });
 
@@ -44,6 +56,7 @@ export const create = mutation({
     repoUrl: v.optional(v.string()),
     imageUrl: v.optional(v.string()),
     techStack: v.array(v.string()),
+    thumbnailId: v.optional(v.id("_storage")),
     isPublished: v.boolean(),
     sortOrder: v.optional(v.number()),
   },
@@ -69,6 +82,7 @@ export const update = mutation({
     repoUrl: v.optional(v.string()),
     imageUrl: v.optional(v.string()),
     techStack: v.optional(v.array(v.string())),
+    thumbnailId: v.optional(v.id("_storage")),
     isPublished: v.optional(v.boolean()),
     sortOrder: v.optional(v.number()),
   },

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -22,6 +22,7 @@ export default defineSchema({
     publishedAt: v.optional(v.number()),
     updatedAt: v.optional(v.number()),
     tags: v.optional(v.array(v.string())),
+    thumbnailId: v.optional(v.id("_storage")),
   })
     .index("by_slug", ["slug"])
     .index("by_published", ["isPublished", "publishedAt"])
@@ -36,6 +37,7 @@ export default defineSchema({
     repoUrl: v.optional(v.string()),
     imageUrl: v.optional(v.string()),
     techStack: v.array(v.string()),
+    thumbnailId: v.optional(v.id("_storage")),
     isPublished: v.boolean(),
     sortOrder: v.optional(v.number()),
     publishedAt: v.optional(v.number()),

--- a/hooks/useThumbnailUrls.ts
+++ b/hooks/useThumbnailUrls.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { Id } from "@/convex/_generated/dataModel";
+
+/**
+ * Batch-resolves thumbnailId fields from an array of items into a URL map.
+ * Avoids N+1 queries by collecting all IDs and calling getUrls once.
+ *
+ * Returns a Record<storageId, url> (only entries that resolved to a URL).
+ */
+export function useThumbnailUrls(
+  items: Array<{ thumbnailId?: Id<"_storage"> }> | undefined
+): Record<string, string> {
+  const storageIds = [
+    ...new Set(
+      (items ?? [])
+        .map((item) => item.thumbnailId)
+        .filter((id): id is Id<"_storage"> => id !== undefined)
+    ),
+  ];
+
+  const urlMap = useQuery(
+    api.files.getUrls,
+    storageIds.length > 0 ? { storageIds } : "skip"
+  );
+
+  if (!urlMap) return {};
+
+  // Filter out null URLs
+  const result: Record<string, string> = {};
+  for (const [id, url] of Object.entries(urlMap)) {
+    if (url) result[id] = url;
+  }
+  return result;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,18 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "*.convex.cloud",
+      },
+      {
+        protocol: "https",
+        hostname: "*.convex.site",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- **Issue #29 (Thumbnails):** Adds Convex file storage for thumbnail images on blog posts and projects. Admin forms now include an upload component with preview/remove. Thumbnails appear on listing cards (right side) and as banner images on detail pages.
- **Issue #23 (Pagination):** Replaces `listPublished` + `.collect()` with cursor-based `listPublishedPaginated` + `usePaginatedQuery`. Blog loads 10 posts at a time, projects load 9 (3×3 grid). Home page remains unchanged (no pagination, just top 3).

### New files
| File | Purpose |
|------|---------|
| `convex/files.ts` | Convex file storage mutations/queries (generateUploadUrl, getUrl, getUrls, deleteFile) |
| `components/admin/ThumbnailUpload.tsx` | Image upload component for admin forms |
| `hooks/useThumbnailUrls.ts` | Batch-resolves thumbnailId → URL map (avoids N+1 queries) |

### Modified files
| File | Change |
|------|--------|
| `convex/schema.ts` | Add `thumbnailId` to posts + projects tables |
| `convex/posts.ts` | Add `thumbnailId` to create/update, add `listPublishedPaginated` query |
| `convex/projects.ts` | Same as posts |
| `next.config.ts` | Add `images.remotePatterns` for `*.convex.cloud` and `*.convex.site` |
| `components/admin/PostForm.tsx` | Integrate ThumbnailUpload, pass thumbnailId to mutations |
| `components/admin/ProjectForm.tsx` | Same as PostForm |
| `components/blog/PostCard.tsx` | Accept `thumbnailUrl` prop, render thumbnail on right |
| `components/projects/ProjectCard.tsx` | Same as PostCard (smaller 80×80 thumbnail) |
| `app/blog/page.tsx` | Switch to `usePaginatedQuery` + "Load more" button |
| `app/projects/page.tsx` | Same + 3-column grid at `lg:` breakpoint |
| `app/page.tsx` | Pass thumbnail URLs to cards (no pagination) |
| `app/blog/[slug]/page.tsx` | Add banner image after header |
| `app/projects/[slug]/page.tsx` | Add banner image between header and description |

## Test plan
- [ ] Admin: create a post with thumbnail → verify upload, preview, save
- [ ] Admin: edit existing post → add/remove thumbnail
- [ ] Blog listing: cards show thumbnail on right side (hidden on mobile)
- [ ] Blog listing: "Load more" button appears and loads next batch
- [ ] Projects listing: 3×3 grid at desktop, thumbnails visible
- [ ] Projects listing: "Load more" button works
- [ ] Home page: still shows 3 posts + 3 projects with thumbnails, no "Load more"
- [ ] Blog post detail: banner image renders when thumbnail exists
- [ ] Project detail: banner image renders when thumbnail exists
- [ ] Cards without thumbnails: no broken layout (graceful fallback)
- [ ] Mobile: thumbnails hidden on small cards, layout intact
- [ ] `npm run typecheck` and `npm run lint` pass clean

Closes #29, closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added thumbnail images to blog posts and projects with responsive display across all devices.
  * Implemented pagination for blog and project listings with "Load more" buttons to improve browsing experience.
  * Enabled thumbnail upload, preview, and management in the admin panel for content creators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->