### PR TITLE
feat: add loading skeletons for blog and projects pages

### DIFF
--- a/app/blog/loading.tsx
+++ b/app/blog/loading.tsx
@@ -1,0 +1,41 @@
+function PostCardSkeleton() {
+  return (
+    <div className="-mx-5 flex items-center gap-5 rounded-xl border border-transparent p-5">
+      <div className="min-w-0 flex-1 space-y-3">
+        {/* Title */}
+        <div className="h-5 w-3/4 rounded animate-shimmer" />
+        {/* Excerpt line 1 */}
+        <div className="h-4 w-full rounded animate-shimmer" />
+        {/* Excerpt line 2 */}
+        <div className="h-4 w-2/3 rounded animate-shimmer" />
+        {/* Date + tags */}
+        <div className="flex items-center gap-3 pt-1">
+          <div className="h-3.5 w-28 rounded animate-shimmer" />
+          <div className="h-5 w-16 rounded-full animate-shimmer" />
+          <div className="h-5 w-14 rounded-full animate-shimmer" />
+        </div>
+      </div>
+      {/* Thumbnail placeholder */}
+      <div className="hidden h-20 w-[120px] shrink-0 rounded-lg animate-shimmer sm:block" />
+    </div>
+  );
+}
+
+export default function BlogLoading() {
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-20">
+      {/* Header */}
+      <div>
+        <div className="h-8 w-24 rounded animate-shimmer" />
+        <div className="mt-3 h-4 w-80 rounded animate-shimmer" />
+      </div>
+
+      {/* Post list */}
+      <div className="mt-10 space-y-1">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <PostCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -167,6 +167,27 @@ body {
   animation: scroll-bounce 2s ease-in-out infinite;
 }
 
+/* Skeleton shimmer */
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+.animate-shimmer {
+  background: linear-gradient(
+    90deg,
+    var(--surface) 25%,
+    var(--surface-hover) 50%,
+    var(--surface) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+
 /* ── Accessibility: respect reduced-motion preference ── */
 @media (prefers-reduced-motion: reduce) {
   .animate-fade-in-up,
@@ -179,7 +200,8 @@ body {
     filter: none !important;
   }
 
-  .animate-scroll-bounce {
+  .animate-scroll-bounce,
+  .animate-shimmer {
     animation: none !important;
   }
 }

--- a/app/projects/loading.tsx
+++ b/app/projects/loading.tsx
@@ -1,0 +1,43 @@
+function ProjectCardSkeleton() {
+  return (
+    <div className="rounded-xl border border-border bg-surface p-6">
+      <div className="flex items-start gap-4">
+        <div className="min-w-0 flex-1 space-y-3">
+          {/* Title */}
+          <div className="h-5 w-3/4 rounded animate-shimmer" />
+          {/* Description line 1 */}
+          <div className="h-3.5 w-full rounded animate-shimmer" />
+          {/* Description line 2 */}
+          <div className="h-3.5 w-2/3 rounded animate-shimmer" />
+        </div>
+        {/* Thumbnail placeholder */}
+        <div className="hidden h-20 w-20 shrink-0 rounded-lg animate-shimmer sm:block" />
+      </div>
+      {/* Tech stack pills */}
+      <div className="mt-4 flex gap-2">
+        <div className="h-5 w-16 rounded-full animate-shimmer" />
+        <div className="h-5 w-20 rounded-full animate-shimmer" />
+        <div className="h-5 w-14 rounded-full animate-shimmer" />
+      </div>
+    </div>
+  );
+}
+
+export default function ProjectsLoading() {
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-20">
+      {/* Header */}
+      <div>
+        <div className="h-8 w-32 rounded animate-shimmer" />
+        <div className="mt-3 h-4 w-64 rounded animate-shimmer" />
+      </div>
+
+      {/* Project grid */}
+      <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <ProjectCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds shimmer-animated skeleton screens for `/blog` and `/projects` routes using Next.js `loading.tsx` convention
- Adds `animate-shimmer` CSS keyframe animation with `prefers-reduced-motion` support
- Skeleton layouts match the actual page structure (post cards, project cards, headers)

Closes #8

## Test plan
- [ ] Navigate to `/blog` — skeleton should flash briefly before content loads
- [ ] Navigate to `/projects` — skeleton should flash briefly before content loads
- [ ] Verify shimmer animation respects `prefers-reduced-motion: reduce`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced blog and projects page loading experience with animated skeleton placeholders that indicate page preparation and content structure.
  * Introduced smooth shimmer animations providing visual feedback during content loading states.
  * Improved accessibility by respecting user preferences for reduced motion throughout animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->