### PR TITLE
ci: add Lighthouse CI audit on pull requests

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,31 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lighthouse:
+    name: Lighthouse Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Wait for Vercel preview deployment
+        uses: patrickedqvist/wait-for-vercel-preview@v1.3.2
+        id: vercel
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          max_timeout: 300
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: |
+            ${{ steps.vercel.outputs.url }}
+            ${{ steps.vercel.outputs.url }}/blog
+            ${{ steps.vercel.outputs.url }}/projects
+            ${{ steps.vercel.outputs.url }}/about
+          configPath: ./lighthouserc.json
+          uploadArtifacts: true
+          temporaryPublicStorage: true

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,22 @@
+{
+  "ci": {
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.9 }],
+        "categories:accessibility": ["error", { "minScore": 0.9 }],
+        "categories:best-practices": ["warn", { "minScore": 0.9 }],
+        "categories:seo": ["warn", { "minScore": 0.9 }],
+
+        "first-contentful-paint": ["warn", { "maxNumericValue": 2000 }],
+        "largest-contentful-paint": ["warn", { "maxNumericValue": 3000 }],
+        "cumulative-layout-shift": ["warn", { "maxNumericValue": 0.1 }],
+        "total-blocking-time": ["warn", { "maxNumericValue": 300 }]
+      }
+    },
+    "collect": {
+      "settings": {
+        "preset": "desktop"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to run Lighthouse audits against Vercel preview deployments on PRs to `main`
- Audits 4 key pages: `/`, `/blog`, `/projects`, `/about`
- Configures score thresholds: performance (90+), accessibility (90+ error), best practices (90+), SEO (90+)
- Includes Core Web Vitals assertions (FCP, LCP, CLS, TBT)

## Test plan
- [ ] Open a PR to `main` and verify the Lighthouse CI workflow triggers
- [ ] Confirm it waits for the Vercel preview deployment before running
- [ ] Check that Lighthouse results are uploaded as artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated quality audits that validate performance and accessibility standards on pull requests. These audits enforce minimum thresholds for critical metrics including page rendering performance, visual stability, layout shift, and accessibility compliance across key site pages to ensure consistent user experience quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->